### PR TITLE
Fix: possible use of uninitialized value `GHz`

### DIFF
--- a/CycleTimer.h
+++ b/CycleTimer.h
@@ -146,7 +146,7 @@
               *MHz_str = '\0';
               if (1 == sscanf(after_at, "%f", &MHz)) {
                 //printf("MHz = %f\n", MHz);
-                secondsPerTick_val = 1e-6f / GHz;
+                secondsPerTick_val = 1e-6f / MHz;
                 break;
               }
             }


### PR DESCRIPTION
Original issue: https://github.com/runshenzhu/palmtree/issues/4#issue-1149020049

The calculation of `secondsPerTick_val` in line 149 is not correct. It should be the same as Line 156.