### PR TITLE
Fix: mismatched `new` and `delete`

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -178,7 +178,7 @@ void bench() {
   for (auto &thread : threads)
     thread.join();
 
-  delete buff;
+  delete[] buff;
   LOG(INFO) << "task_nums: " << palmtree.task_nums;
   while(palmtree.task_nums > 0)
     ;
@@ -203,7 +203,7 @@ void populate_palm_tree(palmtree::PalmTree<int, int> *palmtreep, size_t entry_co
     palmtreep->insert(2 * j, 2 * j);
   }
 
-  delete buff;
+  delete[] buff;
 
   // Wait for task finished
   palmtreep->wait_finish();


### PR DESCRIPTION
Memory allocated by `new[]` should be deallocated by `delete[]` instead of `delete`. Otherwise it may cause undefined behavior.

Clang++ will report this problem but G++ will not.

Reference: [new and delete (C++) - Wikipedia](https://en.wikipedia.org/wiki/New_and_delete_(C%2B%2B)#:~:text=Using%20the%20inappropriate%20form%20results)